### PR TITLE
Filetype-specific inversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ You can specify custom togglables with the `setup()` function:
 ```lua
 -- init.lua
 require('nvim-toggler').setup({
-  ['vim'] = 'emacs'
+  global_inversions = {
+   ['vim'] = 'emacs'
+   ['=='] = '!='
+  },
+  filetype_inversions = {  -- overwrite inversions in specific filetypes
+    lua = {
+      ['=='] = '~='
+    }
+  }
 })
 ```
 

--- a/lua/nvim-toggler.lua
+++ b/lua/nvim-toggler.lua
@@ -1,4 +1,4 @@
-local t = vim.tbl_add_reverse_lookup({
+local global_inversions = vim.tbl_add_reverse_lookup({
   ['true'] = 'false',
   ['yes'] = 'no',
   ['on'] = 'off',
@@ -6,8 +6,22 @@ local t = vim.tbl_add_reverse_lookup({
   ['up'] = 'down',
 })
 
+local filetype_inversions = {}
+
 local setup = function(u_tbl)
-  t = vim.tbl_extend('force', t, vim.tbl_add_reverse_lookup(u_tbl or {}))
+  global_inversions = vim.tbl_extend(
+    'force',
+    global_inversions,
+    vim.tbl_add_reverse_lookup(u_tbl.global_inversions or {})
+  )
+
+  for ft, inversions in pairs(u_tbl.filetype_inversions or {}) do
+    filetype_inversions[ft] = vim.tbl_extend(
+      'force',
+      filetype_inversions[ft] or {},
+      vim.tbl_add_reverse_lookup(inversions)
+    )
+  end
 end
 
 local c = {
@@ -16,7 +30,14 @@ local c = {
 }
 
 local toggle = function()
-  local i = vim.tbl_get(t, vim.fn.expand('<cword>'))
+  local i = vim.tbl_get(global_inversions, vim.fn.expand('<cword>'))
+  if filetype_inversions[vim.bo.filetype] then
+    fi = vim.tbl_get(
+      filetype_inversions[vim.bo.filetype],
+      vim.fn.expand('<cword>')
+    )
+    i = fi or i
+  end
   xpcall(function()
     vim.cmd(vim.tbl_get(c, vim.api.nvim_get_mode().mode) .. i)
   end, function()


### PR DESCRIPTION
First off: thanks for the cool plugin :)

I ran into a problem when having different inversions for different filetypes. E.g. in many programming languages the inverse of `==` is `!=`. However, in Lua it is `~=`. I cannot add both to the reverse lookup-table, so I added some changes that allow overriding global inversions for specific filetypes. Perhaps you find it worthwhile. My setup now looks like this: 

```lua
require("nvim-toggler").setup({
    global_inversions = {
        ["True"] = "False",
        ["=="] = "!=",
        ["and"] = "or",
        ["&&"] = "||",
        ["north"] = "south",
        ["east"] = "west",
        ["<="] = ">=",
        ["<<"] = ">>",
        ["<"] = ">",
        ["+"] = "-",
        ["in"] = "out",
        ["*"] = "&",
    },
    filetype_inversions = {
        lua = {
            ["=="] = "~=",
        },
    },
})
```

Of course, this is breaking the current config of users. It would be possible to not stuff the global inversions in its own table (and thus not break existing configs), but in my opinion it is cleaner and more open for future additions to the config this way. I'd love to hear what you think about it.