### PR TITLE
Use tbl_deep_extend for extending opts

### DIFF
--- a/lua/nvim-toggler/init.lua
+++ b/lua/nvim-toggler/init.lua
@@ -18,7 +18,7 @@ local toggle = function()
   local x = vim.fn.col('.')
   local ch = vim.fn.getline('.'):sub(x, x)
   if not Keys.is_keyword(ch) then
-    print("not keyword")
+    print('not keyword')
     return
   end
   -- toggle the word
@@ -26,7 +26,7 @@ local toggle = function()
 end
 
 local setup = function(opts)
-  opts = vim.tbl_extend('force', default_opts, opts or {})
+  opts = vim.tbl_deep_extend('force', default_opts, opts or {})
   Inverse.update(opts.inverses or {})
   if not opts.remove_default_keybinds then
     vim.keymap.set(


### PR DESCRIPTION
Since the config is now a nested table, just using `tbl_extend` would overwrite the 'inverses' table. Now that I write this I'm no longer sure if this is by design, but given the fact that before the refactoring you were extending the defaults, I assume you still are intending to extend them? 