### PR TITLE
Remove duplicates before "inversions" are inverted

### DIFF
--- a/lua/nvim-toggler/inverse.lua
+++ b/lua/nvim-toggler/inverse.lua
@@ -3,12 +3,9 @@ local u = require('nvim-toggler.utils')
 local Inverse = { list = {} }
 
 Inverse.update = function(list)
-  local rl = function()
-    list = vim.tbl_add_reverse_lookup(list or {})
-  end
-  if not u.assert(pcall(rl), u.err.DUPLICATE_INVERSE) then
-    list = {}
-  end
+  list = u.remove_duplicates(list)
+  list = vim.tbl_add_reverse_lookup(list or {})
+
   Inverse.list = vim.tbl_extend('force', Inverse.list, list)
   Keys.update(Inverse.list)
 end

--- a/lua/nvim-toggler/inverse.lua
+++ b/lua/nvim-toggler/inverse.lua
@@ -3,7 +3,7 @@ local u = require('nvim-toggler.utils')
 local Inverse = { list = {} }
 
 Inverse.update = function(list)
-  list = u.remove_duplicates(list)
+  list = u.sanitize_list(list)
   list = vim.tbl_add_reverse_lookup(list or {})
 
   Inverse.list = vim.tbl_extend('force', Inverse.list, list)

--- a/lua/nvim-toggler/utils.lua
+++ b/lua/nvim-toggler/utils.lua
@@ -15,4 +15,19 @@ utils.err = {
   DUPLICATE_INVERSE = 'toggler: inverse config has duplicates.',
 }
 
+-- remove duplicates key/value == value/key if exists
+utils.remove_duplicates = function(list)
+  local cleaned_list = {}
+
+  for key, value in pairs(list) do
+    if not list[value] then
+      cleaned_list[key] = value
+    elseif not cleaned_list[value] and not cleaned_list[key] then
+      cleaned_list[key] = value
+    end
+  end
+
+  return cleaned_list
+end
+
 return utils

--- a/lua/nvim-toggler/utils.lua
+++ b/lua/nvim-toggler/utils.lua
@@ -15,15 +15,30 @@ utils.err = {
   DUPLICATE_INVERSE = 'toggler: inverse config has duplicates.',
 }
 
--- remove duplicates key/value == value/key if exists
-utils.remove_duplicates = function(list)
+-- key/value is valid if not empty and not include control
+-- and whitespace characters
+local function is_valid_key_value(key, value)
+  if value == '' or key == '' then
+    return false
+  elseif value:match('[%s%c]') or key:match('[%s%c]') then
+    return false
+  end
+  return true
+end
+
+-- remove duplicates and invalid pairs key/value
+utils.sanitize_list = function(list)
   local cleaned_list = {}
+  local uniq_values = {}
 
   for key, value in pairs(list) do
-    if not list[value] then
-      cleaned_list[key] = value
-    elseif not cleaned_list[value] and not cleaned_list[key] then
-      cleaned_list[key] = value
+    if not uniq_values[value] and is_valid_key_value(key, value) then
+      if not list[value] then
+        cleaned_list[key] = value
+      elseif not cleaned_list[value] and not cleaned_list[key] then
+        cleaned_list[key] = value
+      end
+      uniq_values[value] = true
     end
   end
 

--- a/lua/nvim-toggler/utils.lua
+++ b/lua/nvim-toggler/utils.lua
@@ -3,7 +3,7 @@ local utils = {}
 -- returns a boolean of the success of the assertion
 utils.assert = function(v, message)
   if not v then
-    print(message)
+    vim.notify(message, vim.log.levels.WARN)
     return false
   end
   return true


### PR DESCRIPTION
First, thanks for a great plugin.

In this PR
1. Implemented the function to remove duplicates before "inversions" are inverted.
Motivation: I think it's not exactly an "error" to disable plugin functionality when user add duplicate rules. (I did it myself when adding `['right] = 'left'` and had no idea why the plugin didn't work);

2. Replaced `print()` to `vim.notify()` to display an error, because if it had been added earlier, I would have found my error at the same time.

Hope it will be helpful.