### PR TITLE
Fixed tests

### DIFF
--- a/lua/nvim-toggler/utils.lua
+++ b/lua/nvim-toggler/utils.lua
@@ -67,7 +67,7 @@ utils.merge = function(def_tbl, user_tbl)
 end
 
 local test_sanitize_tbl = function(recevied, expected)
-  local received = utils.sanitize_tbl(recevied)
+  local received = sanitize_tbl({}, recevied)
   local log = vim.inspect({ received = received, expected = expected })
   for k, v in pairs(expected) do
     local rk, ek, rv, ev = received[k], expected[k], received[v], expected[v]


### PR DESCRIPTION
Motivation:
1. `test_sanitize_tbl` had called `utils.sanitize_tbl` but this function is local (not in utils module);
2. `sanitize_tbl` expected two args but got one - it is thrown the error when `pairs` got nil instead of a table.