### PR TITLE
Changed nvim command to no using register

### DIFF
--- a/lua/nvim-toggler/inverse.lua
+++ b/lua/nvim-toggler/inverse.lua
@@ -9,8 +9,8 @@ Inverse.update = function(list)
 end
 
 local c = {
-  ['n'] = 'norm! ciw',
-  ['v'] = 'norm! c',
+  ['n'] = 'norm! "_ciw',
+  ['v'] = 'norm! "_c',
 }
 
 Inverse.toggle = function()


### PR DESCRIPTION
When plugin toggle word, previous word saved in nvim registers and will be pasting when user type 'p'/'P' e t.c.
I think, for most users, it is not expected behaviour.
About tests: not sure what this changes needed test because it is built-in commands nvim.